### PR TITLE
Remove rails dependency

### DIFF
--- a/rspec_boolean.gemspec
+++ b/rspec_boolean.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency 'rspec-rails', '~> 3.0'
-  spec.add_dependency 'rspec', '~> 3.0'
+  spec.add_dependency 'rspec', '~> 3.3'
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "rake", "~> 11.2"
 end


### PR DESCRIPTION
Hi there, @lorenzosinisi!

I was surprised a bit when I tried to install this tiny gem, and it brought me the whole rails as a dependency. It seems that rspec dependency is sufficient ;)
