### PR TITLE
Clearer failure messages

### DIFF
--- a/lib/rspec_boolean/boolean.rb
+++ b/lib/rspec_boolean/boolean.rb
@@ -4,7 +4,12 @@ RSpec::Matchers.define :be_boolean do |expected|
     return true if actual == true
     return true if actual == false
   end
+
+  failure_message do |actual|
+    "expected #{actual} to be true or false"
+  end
+
   failure_message_when_negated do |actual|
-    "expected that #{actual} would be a true or false"
+    "expected #{actual} to be something other than true or false"
   end
 end

--- a/spec/rspec_boolean_spec.rb
+++ b/spec/rspec_boolean_spec.rb
@@ -5,10 +5,31 @@ describe RspecBoolean do
     expect(RspecBoolean::VERSION).not_to be nil
   end
 
-  it 'does the dirty job of testing boolean values' do
-    expect(false).to be_boolean
+  context 'basic behavior' do
+    it 'does the dirty job of matching true' do
+      expect(true).to be_boolean
+    end
+
+    it 'does the dirty job of matching false' do
+      expect(false).to be_boolean
+    end
+
+    it 'does the dirty job of testing negations of boolean values' do
+      expect("test").to_not be_boolean
+    end
   end
-  it 'does the dirty job of testing negations of boolean values' do
-    expect("test").to_not be_boolean
+
+  context 'failure messages' do
+    it 'gives details when a value should have been boolean' do
+      expect {
+        expect(42).to be_boolean # should fail
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError, 'expected 42 to be true or false')
+    end
+
+    it 'gives details when a value should have been something else' do
+      expect {
+        expect(true).not_to be_boolean # should fail
+      }.to raise_error(RSpec::Expectations::ExpectationNotMetError, 'expected true to be something other than true or false')
+    end
   end
 end


### PR DESCRIPTION
Previously, the following failing assertion:

    expect(true).not_to be_boolean

...would result in this failure message:

    expected that true would be a true or false

This wording sounds like we were expecting the value to be `true`, but our spec will only pass if it's _not_ `true` or `false`.

With this change, the error message for negative assertions such as `not_to` will more clearly explain what the spec was expecting.